### PR TITLE
Patch for JsonFormatter

### DIFF
--- a/src/WebApiContrib.Formatting.Jsonp/JsonpMediaTypeFormatter.cs
+++ b/src/WebApiContrib.Formatting.Jsonp/JsonpMediaTypeFormatter.cs
@@ -97,8 +97,7 @@ namespace WebApiContrib.Formatting.Jsonp
                 return new JsonpMediaTypeFormatter(request, callback, _jsonMediaTypeFormatter, _callbackQueryParameter);
             }
 
-            // TODO: Should this return the existing JSON media type formatter?
-            throw new HttpResponseException(request.CreateErrorResponse(HttpStatusCode.BadRequest, "The request was not a valid JSON-P request."));
+            return _jsonMediaTypeFormatter;
         }
 
         /// <summary>


### PR DESCRIPTION
I was trying to use this on a project. Your code asked if it would be better if the code would return the existing JsonSerializer rather than throwing an exception.

I ran a few tests and the JsonSerializer wins out -- the exception crashes the web server, or at least IIS express. Null gets an error. But this seems to give me json when I don't explicitly ask for jsonp.
