### PR TITLE
Prevent stack overflow when requesting plain JSON data

### DIFF
--- a/src/WebApiContrib.Formatting.Jsonp/JsonpMediaTypeFormatter.cs
+++ b/src/WebApiContrib.Formatting.Jsonp/JsonpMediaTypeFormatter.cs
@@ -97,8 +97,8 @@ namespace WebApiContrib.Formatting.Jsonp
                 return new JsonpMediaTypeFormatter(request, callback, _jsonMediaTypeFormatter, _callbackQueryParameter);
             }
 
-            // TODO: Should this return the existing JSON media type formatter?
-            throw new HttpResponseException(request.CreateErrorResponse(HttpStatusCode.BadRequest, "The request was not a valid JSON-P request."));
+            // Return the existing formatter. If we return an error here we'll get into an infinite loop trying to send that error to the client.
+            return _jsonMediaTypeFormatter;
         }
 
         /// <summary>


### PR DESCRIPTION
I had a problem with stack overflows when using this library. If we throw an error when this isn't a JSONP request then it will try to send the error to the client, at which point it loops endlessly trying to return error after error.
