### PR TITLE
Update JsonpMediaTypeFormatter.cs

### DIFF
--- a/src/WebApiContrib.Formatting.Jsonp/JsonpMediaTypeFormatter.cs
+++ b/src/WebApiContrib.Formatting.Jsonp/JsonpMediaTypeFormatter.cs
@@ -101,7 +101,7 @@ namespace WebApiContrib.Formatting.Jsonp
                 return new JsonpMediaTypeFormatter(request, callback, _jsonMediaTypeFormatter, _callbackQueryParameter);
             }
 
-            throw new InvalidOperationException(Properties.Resources.NoCallback);
+            return new JsonpMediaTypeFormatter(_jsonMediaTypeFormatter);
         }
 
         /// <summary>


### PR DESCRIPTION
Line 104: Modification to process non-jsonp requests within the same context. i.e. POST, PUT, PATCH, DELETE, etc. Currently, it will throw the InvalidOperationException if a callback is not present, thus failing non-GET requests.
