### PR TITLE
Remove useless dependencies (like System.Web) from Jsonp formatter/tests...

### DIFF
--- a/src/WebApiContrib.Formatting.Jsonp/WebApiContrib.Formatting.Jsonp.csproj
+++ b/src/WebApiContrib.Formatting.Jsonp/WebApiContrib.Formatting.Jsonp.csproj
@@ -35,9 +35,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -45,13 +42,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.0.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web.Http, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.0.0\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HttpConfigurationExtensions.cs" />

--- a/test/WebApiContrib.Formatting.Jsonp.Tests/WebApiContrib.Formatting.Jsonp.Tests.csproj
+++ b/test/WebApiContrib.Formatting.Jsonp.Tests/WebApiContrib.Formatting.Jsonp.Tests.csproj
@@ -48,16 +48,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.0.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web.Http, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.0.0\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="JsonpMediaTypeFormatterTests.cs" />


### PR DESCRIPTION
Greetings,

I've removed useless System.Web++ references. It could be very useful when somebody wants to use your jsonp formatter outside of legacy oriented IIS container (owin must win). There's no need to reference System.Web in main project at all. Many thanks.

Signed-off-by: Victor Bartel <victor.bartel@dgtresor.gouv.fr>